### PR TITLE
Fix tax calculation bug on expenses

### DIFF
--- a/src/Spryker/Zed/Tax/Business/Model/AccruedTaxCalculator.php
+++ b/src/Spryker/Zed/Tax/Business/Model/AccruedTaxCalculator.php
@@ -107,10 +107,6 @@ class AccruedTaxCalculator implements AccruedTaxCalculatorInterface
      */
     public function resetRoundingErrorDelta($identifier = null)
     {
-        $br = static::$roundingErrorBucket;
-
-        $br = 11;
-
         static::$roundingErrorBucket = [];
         static::$roundingErrorBucket[static::DEFAULT_BUCKET_NAME] = 0;
     }

--- a/src/Spryker/Zed/Tax/Business/Model/AccruedTaxCalculator.php
+++ b/src/Spryker/Zed/Tax/Business/Model/AccruedTaxCalculator.php
@@ -59,7 +59,7 @@ class AccruedTaxCalculator implements AccruedTaxCalculatorInterface
      */
     public function getTaxValueFromNetPrice($price, $taxRate, $identifier = null)
     {
-        $taxAmount = $this->priceCalculationHelper->getTaxValueFromNetPrice($price, $taxRate);
+        $taxAmount = $this->priceCalculationHelper->getTaxValueFromNetPrice($price, $taxRate, false);
 
         $taxAmount += $this->getRoundingErrorDelta($identifier);
 

--- a/src/Spryker/Zed/Tax/Business/Model/AccruedTaxCalculator.php
+++ b/src/Spryker/Zed/Tax/Business/Model/AccruedTaxCalculator.php
@@ -36,7 +36,7 @@ class AccruedTaxCalculator implements AccruedTaxCalculatorInterface
      * @param bool $round
      * @param string|null $identifier
      *
-     * @return float
+     * @return int
      */
     public function getTaxValueFromPrice($price, $taxRate, $round = false, $identifier = null)
     {

--- a/src/Spryker/Zed/Tax/Business/Model/Calculator/TaxAmountAfterCancellationCalculator.php
+++ b/src/Spryker/Zed/Tax/Business/Model/Calculator/TaxAmountAfterCancellationCalculator.php
@@ -92,7 +92,7 @@ class TaxAmountAfterCancellationCalculator implements CalculatorInterface
             $taxAmount = $this->calculateTaxAmount(
                 $canceledTaxableAmount,
                 $expenseTransfer->getTaxRate(),
-                $calculableObjectTransfer->getPriceMode()
+                CalculationPriceMode::PRICE_MODE_GROSS
             );
 
             $expenseTransfer->setTaxAmountAfterCancellation($expenseTransfer->getSumTaxAmount() - $taxAmount);

--- a/src/Spryker/Zed/Tax/Business/Model/PriceCalculationHelper.php
+++ b/src/Spryker/Zed/Tax/Business/Model/PriceCalculationHelper.php
@@ -97,12 +97,13 @@ class PriceCalculationHelper implements PriceCalculationHelperInterface
     /**
      * @param int $netPrice
      * @param float $taxPercentage
+     * @param bool $round
      *
      * @throws \Spryker\Zed\Tax\Business\Model\Exception\CalculationException
      *
      * @return float|int
      */
-    public function getTaxValueFromNetPrice($netPrice, $taxPercentage)
+    public function getTaxValueFromNetPrice($netPrice, $taxPercentage, bool $round = true)
     {
         $price = (int)$netPrice;
 
@@ -111,6 +112,10 @@ class PriceCalculationHelper implements PriceCalculationHelperInterface
         }
 
         $amount = $netPrice * $taxPercentage / 100;
+
+        if (!$round) {
+            return $amount;
+        }
 
         return (int)round($amount);
     }

--- a/src/Spryker/Zed/Tax/Business/Model/PriceCalculationHelperInterface.php
+++ b/src/Spryker/Zed/Tax/Business/Model/PriceCalculationHelperInterface.php
@@ -46,8 +46,9 @@ interface PriceCalculationHelperInterface
     /**
      * @param int $netPrice
      * @param float $taxPercentage
+     * @param bool $round
      *
      * @return float|int
      */
-    public function getTaxValueFromNetPrice($netPrice, $taxPercentage);
+    public function getTaxValueFromNetPrice($netPrice, $taxPercentage, bool $round = true);
 }


### PR DESCRIPTION
This fixes a small issue on the tax calculation. Like for the items, the expense tax calculation should always use GROSS mode as the PriceToPayAggregation always contains the taxes (regardless of the price mode). If the calculable object uses NET mode, this will result in wrong expense tax calculations. That could lead to grave problems with discrepancies between the cart calculation (where it is correct) and that one, because the rounding delta correction will make it even more confusing.